### PR TITLE
publicリポジトリのため、hfトークンが記載されているのは不適切（トークンは再発行済み）

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     #environment:
     #  - DISPLAY=$DISPLAY
-    #  - HF_TOKEN=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
+    #  - HF_TOKEN=
     volumes:
       #./home:/homeだと、dockerユーザを作った時にcondaがactiveにならない
       - ./work:/home/docker/work


### PR DESCRIPTION
## 概要
title

## 修正内容
- hfトークンの記載を削除した。
- hfトークンは再発行済み

## 影響範囲
使用時にhfトークンを個別に指定する必要がある

## レビュー観点
特になし

## 補足